### PR TITLE
Not exporting robolectric android-all jars to test targets

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -16,8 +16,7 @@ ANDROID_ALL_JARS = [
 
 java_library(
     name = "android-all",
-    data = [":robolectric-deps.properties"],
-    exports = [":android-all-jars"],
+    data = [":robolectric-deps.properties"] + ANDROID_ALL_JARS,
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**Background**
The root cause of this issue is that, bazel rules will by default put all robolectric-android-all jars into the test runfile's runtime classpath, which is incorrect because only Robolectric Sandbox's environment should load those classes and decide which one to be used based on the sdk value specified in tests. 

Related issue: https://github.com/bazelbuild/bazel/issues/11445

**Change**
Not exporting robolectric android-all jars to test targets

**Test**
my local android_local_test passed and we've been applied this change on our internal repo