### PR TITLE
Update doc for 4.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Add the `robolectric` and `rules_jvm_external` repositories in your WORKSPACE fi
 ```python
 http_archive(
     name = "robolectric",
-    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.4.tar.gz"],
-    strip_prefix = "robolectric-bazel-4.4",
+    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.5.tar.gz"],
+    strip_prefix = "robolectric-bazel-4.5",
 )
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
 robolectric_repositories()
@@ -25,7 +25,7 @@ http_archive(
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
-        "org.robolectric:robolectric:4.4",
+        "org.robolectric:robolectric:4.5",
     ],
     repositories = [
         "https://maven.google.com",


### PR DESCRIPTION
There are two issues, https://github.com/robolectric/robolectric-bazel/issues/14 and https://github.com/robolectric/robolectric-bazel/issues/12, to request 4.5 release to support `Robolectric` 4.5 and 4.5.1. There are some related PRs to [add android-all-11 supporting](https://github.com/robolectric/robolectric-bazel/pull/11) and [fix android-alls](https://github.com/robolectric/robolectric-bazel/pull/10), and they complete things needed by `Robolectric` 4.5 and 4.5.1. Maybe we can release a new version for users. I am not sure whether a single 4.5.1 version for `Robolectric` 4.5.1 only to couple `Robolectric` version and bazel rules version.

Close https://github.com/robolectric/robolectric-bazel/issues/12.