### PR TITLE
Load robolectric_repositories in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,5 @@
 workspace(name = "robolectric")
+
+load("//bazel:robolectric.bzl", "robolectric_repositories")
+
+robolectric_repositories()


### PR DESCRIPTION
Allows us to run `bazel build //...` to fetch the jars from within this repository.