### PR TITLE
Update source.template.json to use a stable URL

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "robolectric-bazel-{TAG}",
-  "url": "https://github.com/robolectric/robolectric-bazel/archive/{TAG}.tar.gz"
+  "url": "https://github.com/robolectric/robolectric-bazel/archive/refs/tags/{TAG}.tar.gz"
 }


### PR DESCRIPTION
The bcr PR creation worked but the CI checks failed because we aren't using a stable URL for the release.

https://buildkite.com/bazel/bcr-presubmit/builds/1196#0187911a-95a9-4951-9836-b0374c4dce6a/125-132