### PR TITLE
Update rules_jvm_external to 5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project provides build rules for integrating Robolectric into Bazel
 projects.
 
-##  Releases
+## Releases
 
 <a href="https://github.com/robolectric/robolectric-bazel/releases/latest"><img src="https://img.shields.io/github/v/release/robolectric/robolectric-bazel?display_name=tag&label=Latest%20Stable%20Release"/></a>
 <br/>
@@ -47,7 +47,7 @@ http_archive(
     name = "rules_jvm_external",
     strip_prefix = "rules_jvm_external-5.3",
     sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.5.zip",
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
 )
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
@@ -60,7 +60,6 @@ maven_install(
     ],
 )
 ```
-
 
 ### And Finally
 

--- a/examples/simple/MODULE.bazel
+++ b/examples/simple/MODULE.bazel
@@ -9,7 +9,7 @@ local_path_override(module_name = "rules_robolectric", path = "../..")
 
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "rules_android", version = "0.1.1")
-bazel_dep(name = "rules_jvm_external", version = "5.2")
+bazel_dep(name = "rules_jvm_external", version = "5.3")
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -34,9 +34,9 @@ android_sdk_repository(name = "androidsdk")
 
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "b17d7388feb9bfa7f2fa09031b32707df529f26c91ab9e5d909eb1676badd9a6",
-    strip_prefix = "rules_jvm_external-4.5",
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.5.zip",
+    sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
+    strip_prefix = "rules_jvm_external-5.3",
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")


### PR DESCRIPTION
What's included:
- Some minor formatting changes
- Use the correct tar.gz URL in the example for the latest rules_jvm_external release.
- Upgrade rules_jvm_external in the examples to 5.3