### PR TITLE
Revert .bcr presubmit changes

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,30 +5,5 @@ tasks:
   verify_targets:
     name: "Verify build targets"
     platform: ${{ platform }}
-    build_flags:
-      - "--enable_bzlmod=false"
-    build_targets:
-      - "@robolectric//bazel:android-all"
-  verify_targets_bzlmod:
-    name: "Verify build targets with bzlmod"
-    platform: ${{ platform }}
-    build_flags:
-      - "--enable_bzlmod=true"
     build_targets:
       - "@rules_robolectric//bazel:android-all"
-  verify_examples:
-    name: "Verify build targets"
-    platform: ${{ platform }}
-    working_directory: examples/simple
-    test_flags:
-      - "--enable_bzlmod=false"
-    test_targets:
-      - "//:SparseArraySetTest"
-  verify_examples_bzlmod:
-    name: "Verify build targets"
-    platform: ${{ platform }}
-    working_directory: examples/simple
-    test_flags:
-      - "--enable_bzlmod=true"
-    test_targets:
-      - "//:SparseArraySetTest"


### PR DESCRIPTION
Removing the examples from the bcr presubmit file since they aren't working correctly right now. We build these examples already from within this repo.