### PR TITLE
Update the release archive name to rules_robolectric to match the rules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,4 +15,4 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v5
     with:
       prerelease: false
-      release_files: robolectric-bazel-*.tar.gz
+      release_files: rules_robolectric-*.tar.gz

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -8,7 +8,7 @@ readonly TAG=${GITHUB_REF_NAME}
 # The prefix is chosen to match what GitHub generates for source archives.
 # This guarantees that users can easily switch from a released artifact to a source archive
 # with minimal differences in their code (e.g. strip_prefix remains the same)
-readonly PREFIX="robolectric-bazel-${TAG}"
+readonly PREFIX="rules_robolectric-${TAG}"
 readonly ARCHIVE="${PREFIX}.tar.gz"
 
 # NB: configuration for 'git archive' is in /.gitattributes


### PR DESCRIPTION
More of a correctness change so that the archive name mirrors what the ruleset name is in the central registry.