### PR TITLE
Make robolectric-deps.properties public

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -30,6 +30,7 @@ genrule(
     outs = ["robolectric-deps.properties"],
     cmd = "$(location :gen-deps) $(locations :android-all-jars-filegroup) > $@",
     tools = [":gen-deps"],
+    visibility = ["//visibility:public"],
 )
 
 py_binary(


### PR DESCRIPTION
Seems this properties file contains essential information that need to be passed from users if they don't have their custom properties files. Make it public so users can declare dependency on it.