### PR TITLE
Add Bazel version to presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,9 +1,11 @@
 matrix:
   platform: ["macos", "ubuntu2004"]
+  bazel: ["6.x", "7.x"]
 
 tasks:
   verify_targets:
     name: "Verify build targets"
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     build_targets:
       - "@rules_robolectric//bazel:android-all"


### PR DESCRIPTION
The BCR now requires that we specify a Bazel version.