### PR TITLE
Add windows and macos x86 & arm as CI running OSes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-2022, macos-13, macos-14]
         bzlmod: [true, false]
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,7 +39,7 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest, windows-2022, macos-13, macos-14]
         bzlmod: [ true, false ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Robolectric uses these platforms to run native graphics tests. Maybe we can run robolectric-bazel with these platforms on CI too.