### PR TITLE
Remove macos-14 from ci platform

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-13, macos-14]
+        os: [ubuntu-latest, windows-2022, macos-13]
         bzlmod: [true, false]
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,7 +39,7 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-13, macos-14]
+        os: [ubuntu-latest, windows-2022, macos-13]
         bzlmod: [ true, false ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
I don't know why macos-14 build job is often cancelled. Before we find the accurate reason, we need to remove it to make CI stable first.