### PR TITLE
Add supported tag pattern: *.*

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       # Note that we don't use a "v" prefix to help anchor this pattern.
       # This is purely a matter of preference.
       - "*.*.*"
+      - "*.*"
 
 jobs:
   release:


### PR DESCRIPTION
I pushed the tag 4.12 to the upstream, but it doesn't trigger a new release automatically.