### PR TITLE
Update bazel_skylib to 1.6.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,6 +29,6 @@ use_repo(
 )
 
 bazel_dep(name = "rules_java", version = "7.0.6")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
-bazel_dep(name = "bazel_skylib", version = "1.4.2", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,16 @@ robolectric_repositories()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "bazel_skylib",
+    sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
+    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+http_archive(
     name = "buildifier_prebuilt",
     sha256 = "72b5bb0853aac597cce6482ee6c62513318e7f2c0050bc7c319d75d03d8a3875",
     strip_prefix = "buildifier-prebuilt-6.3.3",
@@ -16,10 +26,6 @@ http_archive(
 load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
 
 buildifier_prebuilt_deps()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
 
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 

--- a/bazel/extensions.bzl
+++ b/bazel/extensions.bzl
@@ -1,8 +1,10 @@
 """Definitions for bzlmod module extensions."""
 
+load("@bazel_skylib//lib:modules.bzl", "modules")
 load(":robolectric.bzl", "robolectric_repositories")
 
-def _robolectric_repository_extensions_impl(_):
+def _robolectric_repository_extensions_impl(mctx):
     robolectric_repositories()
+    return modules.use_all_repos(mctx, reproducible = True)
 
 robolectric_repository_extensions = module_extension(implementation = _robolectric_repository_extensions_impl)


### PR DESCRIPTION
Pulling in the latest `bazel_skylib` release and using the new module macros that it provides for the extensions.