### PR TITLE
Make robolectric-bazel work for bazel 6 and 7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-13]
-        bazel: [7.4.1, 8.0.0rc4]
+        bazel: [6.5.0, 7.4.1, 8.0.0rc7]
         bzlmod: [ true, false ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:java_import.bzl", "java_import")
 load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load(":robolectric.bzl", "DEFAULT_AVAILABLE_VERSIONS")
@@ -8,7 +9,19 @@ package(
     ],
 )
 
-_ANDROID_ALL_JARS = ["@{}//jar".format(v.name) for v in DEFAULT_AVAILABLE_VERSIONS]
+[
+    java_import(
+        name = "import_" + v.name,
+        jars = ["@{}//file".format(v.name)],
+        visibility = [
+            ":__pkg__",
+            "//tests:__subpackages__",
+        ],
+    )
+    for v in DEFAULT_AVAILABLE_VERSIONS
+]
+
+_ANDROID_ALL_JARS = ["import_{}".format(v.name) for v in DEFAULT_AVAILABLE_VERSIONS]
 
 java_library(
     name = "android-all",

--- a/bazel/robolectric.bzl
+++ b/bazel/robolectric.bzl
@@ -1,7 +1,7 @@
 """Robolectric repositories
 """
 
-load("@rules_java//java:http_jar.bzl", "http_jar")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def robolectric_version(version, sha256, url = None):
     """Define a struct representation of an instrumented Robolectric jar.
@@ -92,4 +92,4 @@ def robolectric_repositories():
     """Creates http_jar repositories for the given versions of Robolectric.
     """
     for v in DEFAULT_AVAILABLE_VERSIONS:
-        http_jar(name = v.name, url = v.url, downloaded_file_name = "android-all-instrumented-%s.jar" % (v.version), sha256 = v.sha256)
+        http_file(name = v.name, url = v.url, downloaded_file_path = "android-all-instrumented-%s.jar" % (v.version), sha256 = v.sha256)


### PR DESCRIPTION
    * Replace http_jar() with http_file()
    * Create java_library wrappers for each http_file in bazel/BUILD
    * Verified for Bazel 6.5.0 and 7.4.1, bzlmod on/off.
