### PR TITLE
Bump rules_jvm_external to 6.7

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -24,7 +24,7 @@ cat << EOF
 \`\`\`starlark
 bazel_dep(name = "rules_robolectric", version = "${TAG}")
 
-bazel_dep(name = "rules_jvm_external", version = "5.3")
+bazel_dep(name = "rules_jvm_external", version = "6.7")
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [

--- a/examples/simple/MODULE.bazel
+++ b/examples/simple/MODULE.bazel
@@ -12,7 +12,7 @@ local_path_override(
 
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "rules_android", version = "0.1.1")
-bazel_dep(name = "rules_jvm_external", version = "5.3")
+bazel_dep(name = "rules_jvm_external", version = "6.7")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -69,10 +69,18 @@ robolectric_repositories()
 
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
-    strip_prefix = "rules_jvm_external-5.3",
-    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
+    sha256 = "a1e351607f04fed296ba33c4977d3fe2a615ed50df7896676b67aac993c53c18",
+    strip_prefix = "rules_jvm_external-6.7",
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz",
 )
+
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 


### PR DESCRIPTION
Following configurations are necessary to load dependencies of `rules_jvm_external` when using `WORKSPACE`:

```
load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
rules_jvm_external_deps()
load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
rules_jvm_external_setup()
```