### PR TITLE
ci: Add bazel 9.0.0 to verify matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-14]
-        bazel: [6.5.0, 7.4.1, 8.2.1]
+        bazel: [6.5.0, 7.4.1, 8.2.1, 9.0.0]
         bzlmod: [ true, false ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/releases/tag/9.0.0