### PR TITLE
Migrate from `bazelbuild/setup-bazelisk` to `bazel-contrib/setup-bazel` in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,16 +31,12 @@ jobs:
     steps:
       - name: "Checkout the sources"
         uses: actions/checkout@v7
-      - name: Mount bazel caches
-        uses: actions/cache@v6
+      - name: "Setup Bazel"
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-disk-cache
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel') }}
-          restore-keys: bazel-cache-
-      - name: "Setup Bazelisk"
-        uses: bazelbuild/setup-bazelisk@v3
+          bazelisk-cache: true
+          cache-save: true
+          disk-cache: true
       - name: "Building //bazel:android-all"
         run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc build //bazel:android-all --enable_bzlmod=${{ matrix.mode.bzlmod }} --enable_workspace=${{ ! matrix.mode.bzlmod }}
       - name: Verify MODULE.bazel.lock is unchanged
@@ -68,16 +64,12 @@ jobs:
     steps:
       - name: "Checkout the sources"
         uses: actions/checkout@v7
-      - name: Mount bazel caches
-        uses: actions/cache@v6
+      - name: "Setup Bazel"
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-disk-cache
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel') }}
-          restore-keys: bazel-cache-
-      - name: "Setup Bazelisk"
-        uses: bazelbuild/setup-bazelisk@v3
+          bazelisk-cache: true
+          cache-save: true
+          disk-cache: true
       - name: "Running integration tests"
         working-directory: examples/simple
         run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc test //:SparseArraySetTest --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ ! matrix.bzlmod }}


### PR DESCRIPTION
The `bazelbuild/setup-bazelisk` is archived since March 11, 2024: https://github.com/bazelbuild/setup-bazelisk
Instead, it is recommended to use `bazel-contrib/setup-bazel`: https://github.com/bazel-contrib/setup-bazel

The migration guide is available here: https://github.com/bazel-contrib/setup-bazel#migrating-from-bazelbuildsetup-bazelisk
