### PR TITLE
Move to hermetic_android_toolchains

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,4 +5,3 @@ common --enable_bzlmod
 common --enable_workspace
 # Android SDK 36 requires Java 21
 common --java_runtime_version=21
-common --repo_env=ACCEPTED_ANDROID_SDK_LICENSE_VERSION=37.0

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["macos", "ubuntu2004"]
-  bazel: ["7.x", "8.x", "9.x"]
+  bazel: ["8.x", "9.x"]
 
 tasks:
   verify_targets:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,10 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-14]
         bazel: [8.4.2, 9.1.0]
-        bzlmod: [ true, false ]
-        exclude:
-          - bazel: 9.1.0
-            bzlmod: false
+        bzlmod: [ true ]
     runs-on: ${{ matrix.os }}
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-14]
-        bazel: [7.4.1, 9.1.0]
+        bazel: [8.4.2, 9.1.0]
         bzlmod: [ true, false ]
         exclude:
           - bazel: 9.1.0

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,3 +34,22 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_python", version = "0.40.0")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+bazel_dep(name = "hermetic_android_toolchains", version = "0.3.0", dev_dependency = True)
+bazel_dep(name = "rules_android", version = "0.7.3", dev_dependency = True)
+
+android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android", dev_dependency = True)
+android.sdk(
+    build_tools_version = "37.0.0",
+    version = "37.0",
+)
+use_repo(android, "androidsdk")
+
+# Make @rules_android's @androidsdk labels resolve to the hermetic SDK.
+rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension", dev_dependency = True)
+
+override_repo(rules_android_sdk, "androidsdk")
+
+register_toolchains(
+    "@androidsdk//:all",
+    dev_dependency = True,
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,22 +35,3 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_python", version = "0.40.0")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.3", dev_dependency = True)
-bazel_dep(name = "hermetic_android_toolchains", version = "0.3.0", dev_dependency = True)
-bazel_dep(name = "rules_android", version = "0.7.3", dev_dependency = True)
-
-android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android", dev_dependency = True)
-android.sdk(
-    build_tools_version = "37.0.0",
-    version = "37.0",
-)
-use_repo(android, "androidsdk")
-
-# Make @rules_android's @androidsdk labels resolve to the hermetic SDK.
-rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension", dev_dependency = True)
-
-override_repo(rules_android_sdk, "androidsdk")
-
-register_toolchains(
-    "@androidsdk//:all",
-    dev_dependency = True,
-)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     name = "rules_robolectric",
     # Note: the publish-to-BCR app will patch this line to stamp the version being published.
     version = "0.0.0",
-    bazel_compatibility = [">=7.0.0"],
+    bazel_compatibility = [">=8.4.2"],
     compatibility_level = 1,
 )
 

--- a/examples/simple/MODULE.bazel
+++ b/examples/simple/MODULE.bazel
@@ -11,8 +11,10 @@ local_path_override(
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_android", version = "0.7.1")
 bazel_dep(name = "rules_jvm_external", version = "6.9")
+
+bazel_dep(name = "hermetic_android_toolchains", version = "0.3.0", dev_dependency = True)
+bazel_dep(name = "rules_android", version = "0.7.3", dev_dependency = True)
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
@@ -29,10 +31,19 @@ maven.install(
 )
 use_repo(maven, "maven")
 
-remote_android_extensions = use_extension("@rules_android//bzlmod_extensions:android_extensions.bzl", "remote_android_tools_extensions")
-use_repo(remote_android_extensions, "android_tools")
+android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android", dev_dependency = True)
+android.sdk(
+    build_tools_version = "37.0.0",
+    version = "37.0",
+)
+use_repo(android, "androidsdk")
 
-android_sdk_repository_extension = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
-use_repo(android_sdk_repository_extension, "androidsdk")
+# Make @rules_android's @androidsdk labels resolve to the hermetic SDK.
+rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension", dev_dependency = True)
 
-register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")
+override_repo(rules_android_sdk, "androidsdk")
+
+register_toolchains(
+    "@androidsdk//:all",
+    dev_dependency = True,
+)


### PR DESCRIPTION
## Summary

- Configure hermetic Android SDK/toolchains for the simple Bzlmod example only.
- Pin the example to rules_android 0.7.3 and hermetic_android_toolchains 0.3.0.
- Keep the Bazel 8.4.2 minimum for the hermetic sample integration.
- Remove Bazel 7 from CI/BCR presubmit coverage.

## Testing

- GitHub Actions root builds on Bazel 8.2.1 WORKSPACE and Bazel 9.1.0 Bzlmod across Linux, macOS, and Windows.
- GitHub Actions sample integration tests on Bazel 8.4.2 and 9.1.0 Bzlmod across Linux, macOS, and Windows.
- Buildifier check.