### PR TITLE
Pass java.base/jdk.internal.access=ALL-UNNAMED

### DIFF
--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -4,6 +4,7 @@ android_local_test(
     name = "SparseArraySetTest",
     srcs = ["SparseArraySetTest.java"],
     custom_package = "org.robolectric.integrationtests.sparsearray",
+    jvm_flags = ["--add-exports=java.base/jdk.internal.access=ALL-UNNAMED"],
     test_class = "org.robolectric.integrationtests.sparsearray.SparseArraySetTest",
     deps = [
         "@maven//:com_google_truth_truth",


### PR DESCRIPTION
```
2) testSparseArrayBracketOperator_callsSetMethodPreApi31(org.robolectric.integrationtests.sparsearray.SparseArraySetTest)
java.lang.RuntimeException: Failed to interact with raw FileDescriptor internals; perhaps JRE has changed?
	at org.robolectric.interceptors.AndroidInterceptors$FileDescriptorInterceptor.setInt(AndroidInterceptors.java:88)
	at com.android.internal.os.ApplicationSharedMemory.create(ApplicationSharedMemory.java:106)
	at org.robolectric.android.internal.AndroidTestEnvironment.setUpApplicationState(AndroidTestEnvironment.java:245)
	at org.robolectric.RobolectricTestRunner.beforeTest(RobolectricTestRunner.java:327)
	at org.robolectric.internal.SandboxTestRunner.runInSandbox(SandboxTestRunner.java:453)
	at org.robolectric.internal.SandboxTestRunner.executeInSandbox(SandboxTestRunner.java:420)
	at org.robolectric.internal.SandboxTestRunner$5.evaluate(SandboxTestRunner.java:405)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.robolectric.internal.SandboxTestRunner.access$000(SandboxTestRunner.java:64)
	at org.robolectric.internal.SandboxTestRunner$4.evaluate(SandboxTestRunner.java:294)
	at org.robolectric.internal.SandboxTestRunner$2.evaluate(SandboxTestRunner.java:260)
	at org.robolectric.internal.SandboxTestRunner$3.lambda$evaluate$0(SandboxTestRunner.java:280)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThreadWithClassLoader$1(Sandbox.java:112)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.IllegalAccessException: class org.robolectric.interceptors.AndroidInterceptors$FileDescriptorInterceptor cannot access class jdk.internal.access.SharedSecrets (in module java.base) because module java.base does not export jdk.internal.access to unnamed module @50b7a89f
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:394)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:714)
	at java.base/java.lang.reflect.Method.invoke(Method.java:571)
	at org.robolectric.interceptors.AndroidInterceptors$FileDescriptorInterceptor.setInt(AndroidInterceptors.java:83)
	at com.android.internal.os.ApplicationSharedMemory.$$robo$$com_android_internal_os_ApplicationSharedMemory$create(ApplicationSharedMemory.java:106)
	at com.android.internal.os.ApplicationSharedMemory.create(ApplicationSharedMemory.java)
	... 17 more

```