### PR TITLE
Change registry_fork to robolectric/bazel-central-registry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       attestations: write # Attest provenance
     with:
       tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
-      registry_fork: bazel-contrib/bazel-central-registry
+      registry_fork: robolectric/bazel-central-registry
       # release.yaml uses bazel-contrib/.github@v7, which does not produce
       # attestations, so skip attestation upload.
       attest: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       attestations: write # Attest provenance
     with:
       tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
-      registry_fork: robolectric/bazel-central-registry
+      registry_fork: Bencodes/bazel-central-registry
       # release.yaml uses bazel-contrib/.github@v7, which does not produce
       # attestations, so skip attestation upload.
       attest: false


### PR DESCRIPTION
Point the publish job at the forked BCR repo where the bot has access to be able to push.