### PR TITLE
Migrate CI from setup-bazelisk to setup-bazel

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -10,15 +10,13 @@ build --host_cxxopt=-std=c++17
 
 # Debug where options came from
 build --announce_rc
+# This directory is configured in GitHub actions to be persisted between runs.
+# We do not enable the repository cache to cache downloaded external artifacts
+# as these are generally faster to download again than to fetch them from the
+# GitHub actions cache.
+build --disk_cache=~/.cache/bazel-disk-cache
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 test --test_env=XDG_CACHE_HOME
-
-# rules_android invokes its Windows sh_binary tools through their runfiles tree.
-common:windows --enable_runfiles
-
-# rules_android's Starlark android_local_test launcher is a Bash script without
-# a Windows executable extension; run it through Bash for Bazel's test wrapper.
-test:windows --run_under=bash

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -18,3 +18,7 @@ test --test_env=XDG_CACHE_HOME
 
 # rules_android invokes its Windows sh_binary tools through their runfiles tree.
 common:windows --enable_runfiles
+
+# rules_android's Starlark android_local_test launcher is a Bash script without
+# a Windows executable extension; run it through Bash for Bazel's test wrapper.
+test:windows --run_under=bash

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -10,13 +10,11 @@ build --host_cxxopt=-std=c++17
 
 # Debug where options came from
 build --announce_rc
-# This directory is configured in GitHub actions to be persisted between runs.
-# We do not enable the repository cache to cache downloaded external artifacts
-# as these are generally faster to download again than to fetch them from the
-# GitHub actions cache.
-build --disk_cache=~/.cache/bazel-disk-cache
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 test --test_env=XDG_CACHE_HOME
+
+# rules_android invokes its Windows sh_binary tools through their runfiles tree.
+common:windows --enable_runfiles

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,16 +27,12 @@ jobs:
     steps:
       - name: "Checkout the sources"
         uses: actions/checkout@v7
-      - name: Mount bazel caches
-        uses: actions/cache@v6
+      - name: "Setup Bazel"
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-disk-cache
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl') }}
-          restore-keys: bazel-cache-
-      - name: "Setup Bazelisk"
-        uses: bazelbuild/setup-bazelisk@v3
+          bazelisk-cache: true
+          cache-save: true
+          disk-cache: true
       - name: "Building //bazel:android-all"
         run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc build //bazel:android-all
       - name: Verify MODULE.bazel.lock is unchanged
@@ -61,16 +57,12 @@ jobs:
     steps:
       - name: "Checkout the sources"
         uses: actions/checkout@v7
-      - name: Mount bazel caches
-        uses: actions/cache@v6
+      - name: "Setup Bazel"
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-disk-cache
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl') }}
-          restore-keys: bazel-cache-
-      - name: "Setup Bazelisk"
-        uses: bazelbuild/setup-bazelisk@v3
+          bazelisk-cache: true
+          cache-save: true
+          disk-cache: true
       - name: "Running integration tests"
         working-directory: examples/simple
         run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc test //:SparseArraySetTest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-14]
+        os: [ubuntu-latest, macos-14]
         bazel: [8.7.0, 9.2.0]
     runs-on: ${{ matrix.os }}
     env:
@@ -34,7 +34,7 @@ jobs:
           cache-save: true
           disk-cache: true
       - name: "Building //bazel:android-all"
-        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc ${{ runner.os == 'Windows' && '--windows_enable_symlinks' || '' }} build //bazel:android-all ${{ runner.os == 'Windows' && '--config=windows' || '' }}
+        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc build //bazel:android-all
       - name: Verify MODULE.bazel.lock is unchanged
         if: always()
         shell: bash
@@ -48,7 +48,7 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-14]
+        os: [ubuntu-latest, macos-14]
         bazel: [8.7.0, 9.2.0]
         bzlmod: [ true ]
     runs-on: ${{ matrix.os }}
@@ -65,4 +65,4 @@ jobs:
           disk-cache: true
       - name: "Running integration tests"
         working-directory: examples/simple
-        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc ${{ runner.os == 'Windows' && '--windows_enable_symlinks' || '' }} test //:SparseArraySetTest ${{ runner.os == 'Windows' && '--config=windows' || '' }}
+        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc test //:SparseArraySetTest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           cache-save: true
           disk-cache: true
       - name: "Building //bazel:android-all"
-        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc build //bazel:android-all
+        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc ${{ runner.os == 'Windows' && '--windows_enable_symlinks' || '' }} build //bazel:android-all ${{ runner.os == 'Windows' && '--config=windows' || '' }}
       - name: Verify MODULE.bazel.lock is unchanged
         if: always()
         shell: bash
@@ -65,4 +65,4 @@ jobs:
           disk-cache: true
       - name: "Running integration tests"
         working-directory: examples/simple
-        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc test //:SparseArraySetTest
+        run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc ${{ runner.os == 'Windows' && '--windows_enable_symlinks' || '' }} test //:SparseArraySetTest ${{ runner.os == 'Windows' && '--config=windows' || '' }}


### PR DESCRIPTION
## Summary

- Replace the archived `bazelbuild/setup-bazelisk` action and separate `actions/cache` step with `bazel-contrib/setup-bazel@0.19.0` in both CI jobs.
- Enable Bazelisk caching, disk caching, and cache saving through `setup-bazel`.
- Temporarily remove `windows-2022` from the build and integration-test matrices.

This rebases the work from #154 now that its underlying changes have landed on `master`.

## Windows CI

The previous `setup-bazelisk@v3` step does not support PowerShell, so the Windows jobs were not exercising Bazel correctly. Switching actions exposed a pre-existing Windows failure in the `rules_android` Starlark `android_local_test` launcher used by `//:SparseArraySetTest`:

```text
CreateProcessW("...\\SparseArraySetTest"): %1 is not a valid Win32 application.
(error: 193)
```

`rules_android` currently generates an extensionless Bash script as the `android_local_test` executable. Bazel's Windows test wrapper passes that file to `CreateProcessW`, which requires a native Windows executable. The upstream `rules_android` presubmit also currently excludes Windows unit tests.

Windows is therefore disabled for both CI jobs for now. It can be restored once `rules_android` supplies a native Windows launcher for `android_local_test` and its Windows test coverage is enabled.

## Testing

- Buildifier
- Builds on Ubuntu and macOS with Bazel 8.7.0 and 9.2.0
- `//:SparseArraySetTest` on Ubuntu and macOS with Bazel 8.7.0 and 9.2.0

Verified by https://github.com/robolectric/robolectric-bazel/actions/runs/32550227917
