### PR TITLE
Update example rules_android to 0.7.3

### DIFF
--- a/examples/simple/MODULE.bazel
+++ b/examples/simple/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_android", version = "0.7.1")
+bazel_dep(name = "rules_android", version = "0.7.3")
 bazel_dep(name = "rules_jvm_external", version = "6.9")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")


### PR DESCRIPTION
## Summary

- Update the example app to use rules_android 0.7.3, the latest version published to the Bazel Central Registry.

## Testing

- `bazel --bazelrc=.github/workflows/ci.bazelrc test //:SparseArraySetTest --enable_bzlmod=true --enable_workspace=false`